### PR TITLE
Footer & FAQ changes

### DIFF
--- a/app/views/custom/_gobierto.html.erb
+++ b/app/views/custom/_gobierto.html.erb
@@ -478,3 +478,8 @@ body[data-action="map"] .main_metrics .metric:focus,
 body[data-action="map"] .main_metrics .metric:active {
   background: #C9DCEC;
 }
+
+/* Delete FAQ */
+.disclaimer {
+  display: none;
+}

--- a/app/views/custom/layouts/_footer_ca.html.erb
+++ b/app/views/custom/layouts/_footer_ca.html.erb
@@ -9,6 +9,7 @@
         </div>
         <div class="col-md-2 col-sm-2 clearfix hidden-xs"><a href="http://www.gencat.cat"><img src="/img/NG_logo_generalitat_peu.png" alt="www.gencat.cat"></a></div>
         <div class="col-md-8  col-sm-8 hidden-xs avislegal clearfix">
+          <p>Font de les dades: Generalitat de Catalunya. <a href="https://analisi.transparenciacatalunya.cat/d/4g9s-gzp6">Pressupostos</a> · <a href="https://analisi.transparenciacatalunya.cat/d/e7ah-kha8">Liquidació</a>.</p>
           <p><strong>Avís legal:</strong> La ©Generalitat de Catalunya permet la reutilització de les dades sempre que se citi la font i la data d'actualització, que no es desnaturalitzi la informació i que no es contradigui amb una llicència específica.</p>
         </div>
         <div class="col-md-2 col-sm-2 hidden-xs segu-twit clearfix">

--- a/app/views/custom/layouts/_footer_es.html.erb
+++ b/app/views/custom/layouts/_footer_es.html.erb
@@ -9,6 +9,7 @@
         </div>
         <div class="col-md-2 col-sm-2 clearfix hidden-xs"><a href="http://www.gencat.cat"><img src="/img/NG_logo_generalitat_peu.png" alt="www.gencat.cat"></a></div>
         <div class="col-md-8  col-sm-8 hidden-xs avislegal clearfix">
+          <p>Fuente de datos: Generalitat de Catalunya. <a href="https://analisi.transparenciacatalunya.cat/d/4g9s-gzp6">Presupuestos</a> · <a href="https://analisi.transparenciacatalunya.cat/d/e7ah-kha8">Liquidación</a>.</p>
           <p><strong>Aviso legal:</strong>  La ©Generalitat de Cataluña permite la reutilización de los contenidos y de los datos siempre que se cite la fuente y la fecha de actualización, que no se desnaturalice la información y que no se contradiga con una licencia específica.</p>
         </div>
         <div class="col-md-2 col-sm-2 hidden-xs segu-twit clearfix">


### PR DESCRIPTION
This hides the FAQ on the ranking page and adds two links in the custom footer which link to the data sources.

I am looking for more mentions of the FAQ but I can't find anything. This fix actually hides the data disclaimer, but I wasn't able to think of a better way to do it without changing the markup.